### PR TITLE
Small hyperlink typo fix

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,7 @@ footer_links:
   - name: Github
     url: 'https://github.com/jonmbake'
     internal: false
-  - name: Personal Constiution
+  - name: Personal Constitution
     url: personal_constitution
     internal: true
   - name: Contact


### PR DESCRIPTION
Footer of website says "Personal Constiution" when it's meant to say "Personal Constitution"

The page link is correct, only the hypertext label is misspelled. This corrects that small typo.